### PR TITLE
ENH - Copy students from existing students table to new students table

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:css:syntax": "stylelint \"src/web/**/*.css\" \"src/web/**/*.scss\" \"src/web/**/*.html\" --ignore-pattern \"src/web/dist/*.css\" --cache --config static-analysis/teammates-stylelint.yml",
     "lint:css:styles": "prettier --print-width=120 --single-quote=true \"src/web/**/*.css\" \"src/web/**/*.scss\"",
     "lint:windows:spaces": "lintspaces -n -t -d spaces -l 1 -. \"src/main/**/*.html\" \"src/web/**/*.html\" \"src/**/*.xml\" \"src/**/*.json\" \"src/**/*.properties\" \"*.yml\" \"*.json\" \"*.gradle\" \"static-analysis/*.*ml\" \".gitattributes\"",
-    "lint:nix:spaces": "lintspaces -n -t -d spaces -l 1 --matchdotfiles $(git diff --name-only --diff-filter=ACMRTUXB origin/master HEAD | grep -E \"src/(main|web)/.*.html|src/.*.(xml|json|properties)|*.(yml|json|gradle)|static-analysis/*.*ml|.gitattributes\") || :",
+    "lint:nix:spaces": "lintspaces -n -t -d spaces -l 1 --matchdotfiles $(git diff --name-only --diff-filter=ACMRTUXB origin/master HEAD | grep -E \"src/(main|web)/.*\\.html|src/.*\\.(xml|json|properties)|.*\\.(yml|json|gradle)|static-analysis/.*\\.(xml|yml)\") || :",
     "lint": "run-script-os",
     "lint:windows": "npm-run-all lint:ts lint:css:syntax lint:css:styles lint:windows:spaces -c",
     "lint:nix": "npm-run-all lint:ts lint:css:syntax lint:css:styles lint:nix:spaces -c"

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.spec.ts
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.spec.ts
@@ -8,6 +8,7 @@ import {
 import SpyInstance = jest.SpyInstance;
 import { PerQuestionViewResponsesComponent } from './per-question-view-responses.component';
 import { FeedbackResponsesService } from '../../../../services/feedback-responses.service';
+import testEventEmission from '../../../../test-helpers/test-event-emitter';
 import {
   CommentVisibilityType, FeedbackParticipantType, FeedbackQuestionType,
   NumberOfEntitiesToGiveFeedbackToSetting,
@@ -142,5 +143,53 @@ describe('PerQuestionViewResponsesComponent', () => {
     expect(feedbackResponseSpy).toHaveBeenCalledTimes(1);
     expect(JSON.stringify(component.responsesToShow[0]))
       .toBe(JSON.stringify(responseOutput));
+  });
+
+  it('triggerDeleteCommentEvent: should emit correct responseID and index to deleteCommentEvent', () => {
+    let emittedID: string | undefined;
+    let emittedIndex: number | undefined;
+    testEventEmission(component.deleteCommentEvent, (val) => { emittedID = val.responseId; emittedIndex = val.index; });
+
+    component.triggerDeleteCommentEvent('testID', 5);
+    expect(emittedID).toBe('testID');
+    expect(emittedIndex).toBe(5);
+  });
+
+  it('triggerUpdateCommentEvent: should emit correct responseID and index to updateCommentEvent', () => {
+    let emittedID: string | undefined;
+    let emittedIndex: number | undefined;
+    testEventEmission(component.updateCommentEvent, (val) => { emittedID = val.responseId; emittedIndex = val.index; });
+
+    component.triggerUpdateCommentEvent('testID2', 6);
+    expect(emittedID).toBe('testID2');
+    expect(emittedIndex).toBe(6);
+  });
+
+  it('triggerSaveNewCommentEvent: should emit correct responseID to saveNewCommentEvent', () => {
+    let emittedID: string | undefined;
+    testEventEmission(component.saveNewCommentEvent, (responseId) => { emittedID = responseId; });
+
+    component.triggerSaveNewCommentEvent('testID3');
+    expect(emittedID).toBe('testID3');
+  });
+
+  it('triggerModelChangeForSingleResponse: should emit correct Record to instructorCommentTableModelChange', () => {
+    let emittedRecord: Record<string, CommentTableModel> | undefined;
+    testEventEmission(component.instructorCommentTableModelChange, (record) => { emittedRecord = record; });
+
+    const testRecord: Record<string, CommentTableModel> = { responseId: commentTableModel };
+
+    component.triggerModelChangeForSingleResponse('responseId', commentTableModel);
+    expect(emittedRecord).toEqual(testRecord);
+  });
+
+  it('triggerModelChange: should emit correct instructorCommentTableModel Record to triggerModelChange', () => {
+    let emittedRecord: Record<string, CommentTableModel> | undefined;
+    testEventEmission(component.instructorCommentTableModelChange, (record) => { emittedRecord = record; });
+
+    const testRecord: Record<string, CommentTableModel> = {};
+
+    component.triggerModelChange(testRecord);
+    expect(emittedRecord).toEqual(testRecord);
   });
 });

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -241,6 +241,8 @@
             <tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>
             <span>{{ isQuestionCountOne ? "Submit Response" : "Submit Response for Question " + model.questionNumber }}</span>
           </button>
+          <button type="button" class="btn btn-warning float-end" (click)="resetForm(); resetTooltip.close();" ngbTooltip="Reset your responses for this question to the last submitted state."
+          #resetTooltip="ngbTooltip" (mouseenter)="resetTooltip.open()" [disabled]="!hasResponseChanged">{{ "Reset Question " + model.questionNumber }}</button>
         </div>
       </div>
     </div>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -93,6 +93,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
       this.model.isTabExpandedForRecipients.set(recipient.recipientIdentifier, true);
     });
+    this.hasResponseChanged = Array.from(this.model.hasResponseChangedForRecipients.values()).some((value) => value);
   }
 
   @Input()
@@ -117,6 +118,12 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
   @Output()
   responsesSave: EventEmitter<QuestionSubmissionFormModel> = new EventEmitter();
+
+  @Output()
+  autoSave: EventEmitter<{ id: string, model: QuestionSubmissionFormModel }> = new EventEmitter();
+
+  @Output()
+  resetFeedback: EventEmitter<QuestionSubmissionFormModel> = new EventEmitter<QuestionSubmissionFormModel>();
 
   @ViewChild(ContributionQuestionConstraintComponent)
   private contributionQuestionConstraint!: ContributionQuestionConstraintComponent;
@@ -167,6 +174,8 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
   visibilityStateMachine: VisibilityStateMachine;
   isEveryRecipientSorted: boolean = false;
+
+  autosaveTimeout: any;
 
   constructor(private feedbackQuestionsService: FeedbackQuestionsService,
     private feedbackResponseService: FeedbackResponsesService) {
@@ -219,6 +228,13 @@ export class QuestionSubmissionFormComponent implements DoCheck {
         this.isSaved = false;
       }
     });
+  }
+
+  resetForm(): void {
+    this.resetFeedback.emit(this.model);
+    this.isSaved = true;
+    this.hasResponseChanged = false;
+    clearTimeout(this.autosaveTimeout);
   }
 
   toggleQuestionTab(): void {
@@ -350,7 +366,6 @@ export class QuestionSubmissionFormComponent implements DoCheck {
    */
   triggerRecipientSubmissionFormChange(index: number, field: string, data: any): void {
     if (!this.isFormsDisabled) {
-      this.hasResponseChanged = true;
       this.isSubmitAllClickedChange.emit(false);
       this.model.hasResponseChangedForRecipients.set(this.model.recipientList[index].recipientIdentifier, true);
 
@@ -362,6 +377,12 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
       this.updateIsValidByQuestionConstraint();
       this.formModelChange.emit(this.model);
+
+      this.autoSave.emit({ id: this.model.feedbackQuestionId, model: this.model });
+      clearTimeout(this.autosaveTimeout);
+      this.autosaveTimeout = setTimeout(() => {
+        this.hasResponseChanged = true;
+      }, 100); // 0.1 second to prevent people from trying to immediately reset before autosave kicks in
     }
   }
 
@@ -451,6 +472,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
    * Triggers saving of responses for the specific question.
    */
   saveFeedbackResponses(): void {
+    clearTimeout(this.autosaveTimeout);
     this.isSaved = true;
     this.hasResponseChanged = false;
     this.model.hasResponseChangedForRecipients.forEach(

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -144,7 +144,7 @@
                                [date]="model.submissionStartDate"></tm-datepicker>
               </div>
               <div class="col-md-5">
-                <tm-timepicker id="submission-start-time" [isDisabled]="!model.isEditable" (timeChange)="triggerModelChange('submissionStartTime', $event)"
+                <tm-timepicker id="submission-start-time" [isDisabled]="!model.isEditable" (timeChange)="triggerSubmissionOpeningTimeModelChange('submissionStartTime', $event)"
                                [minDate]="minDateForSubmissionStart" [maxDate]="maxDateForSubmissionStart"
                                [date]="model.submissionStartDate"
                                [minTime]="minTimeForSubmissionStart" [maxTime]="maxTimeForSubmissionStart"

--- a/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
@@ -21,6 +21,7 @@ describe('SessionEditFormComponent', () => {
   let dateTimeService: DateTimeService;
 
   const submissionStartDateField = 'submissionStartDate';
+  const submissionStartTimeField = 'submissionStartTime';
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -92,6 +93,41 @@ describe('SessionEditFormComponent', () => {
     component.triggerSubmissionOpeningDateModelChange(submissionStartDateField, date);
     expect(triggerModelChangeSpy).toHaveBeenCalledWith(submissionStartDateField, date);
     expect(configureSubmissionOpeningTimeSpy).not.toHaveBeenCalled();
+  });
+
+  it('should trigger the change of the model when the submission opening time '
+    + 'changes to before the visibility time', () => {
+    const date: DateFormat = { day: 12, month: 7, year: 2024 };
+    const time: TimeFormat = { hour: 4, minute: 0 };
+    const visibilityTime: TimeFormat = { hour: 14, minute: 0 };
+    const triggerModelChangeSpy = jest.spyOn(component, 'triggerModelChange');
+    const configureSessionVisibleDateTimeSpy = jest.spyOn(component, 'configureSessionVisibleDateTime');
+    component.model.customSessionVisibleDate = date;
+    component.model.submissionStartDate = date;
+    component.model.customSessionVisibleTime = visibilityTime;
+    component.triggerSubmissionOpeningTimeModelChange(submissionStartTimeField, time);
+    expect(triggerModelChangeSpy).toHaveBeenCalledWith(submissionStartTimeField, time);
+    expect(configureSessionVisibleDateTimeSpy).toHaveBeenCalledWith(date, time);
+  });
+
+  it('should adjust the session visibility date if submission opening date is earlier', () => {
+    const date: DateFormat = { day: 12, month: 7, year: 2024 };
+    const time: TimeFormat = { hour: 14, minute: 0 };
+    component.model.customSessionVisibleDate = { day: 13, month: 7, year: 2024 };
+    component.model.customSessionVisibleTime = time;
+    component.configureSessionVisibleDateTime(date, time);
+    expect(component.model.customSessionVisibleDate).toEqual(date);
+    expect(component.model.customSessionVisibleTime).toEqual(time);
+  });
+
+  it('should not adjust the session visibility date and time if submission opening date and time are later', () => {
+    const date: DateFormat = component.minDateForSubmissionStart;
+    const time: TimeFormat = component.minTimeForSubmissionStart;
+    component.model.customSessionVisibleDate = dateTimeService.getDateInstance(moment().subtract(1, 'days'));
+    component.model.customSessionVisibleTime = dateTimeService.getTimeInstance(moment().subtract(1, 'hours'));
+    component.configureSessionVisibleDateTime(date, time);
+    expect(component.model.customSessionVisibleDate).not.toEqual(date);
+    expect(component.model.customSessionVisibleTime).not.toEqual(time);
   });
 
   it('should emit a modelChange event with the updated field when triggerModelChange is called', () => {

--- a/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
@@ -123,8 +123,10 @@ describe('SessionEditFormComponent', () => {
   it('should not adjust the session visibility date and time if submission opening date and time are later', () => {
     const date: DateFormat = component.minDateForSubmissionStart;
     const time: TimeFormat = component.minTimeForSubmissionStart;
-    component.model.customSessionVisibleDate = dateTimeService.getDateInstance(moment().subtract(1, 'days'));
-    component.model.customSessionVisibleTime = dateTimeService.getTimeInstance(moment().subtract(1, 'hours'));
+    component.model.customSessionVisibleDate = dateTimeService
+      .getDateInstance(moment().tz(component.model.timeZone).subtract(1, 'days'));
+    component.model.customSessionVisibleTime = dateTimeService
+      .getTimeInstance(moment().tz(component.model.timeZone).subtract(1, 'hours'));
     component.configureSessionVisibleDateTime(date, time);
     expect(component.model.customSessionVisibleDate).not.toEqual(date);
     expect(component.model.customSessionVisibleTime).not.toEqual(time);

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -101,7 +101,20 @@
                     title="Enroll"
                     id="btn-enroll"
                     name="button-enroll"
-                    class="btn btn-success float-end"
+                    class="btn btn-info"
+                    [disabled]="isEnrolling"
+                    (click)="submitEnrollData()">
+                  <tm-progress-bar *ngIf="isEnrolling"></tm-progress-bar>
+                  <tm-ajax-loading *ngIf="isEnrolling"></tm-ajax-loading>
+                  Copy students
+                </button>
+                <button
+                    [ngClass]="{'w-50': isEnrolling}"
+                    type="submit"
+                    title="Enroll"
+                    id="btn-enroll"
+                    name="button-enroll"
+                    class="btn btn-success"
                     [disabled]="isEnrolling"
                     (click)="submitEnrollData()">
                   <tm-progress-bar *ngIf="isEnrolling"></tm-progress-bar>

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -96,16 +96,16 @@
               </div>
               <div class="enroll-button-group">
                 <button
-                    [ngClass]="{'w-50': isEnrolling}"
-                    type="submit"
-                    title="Enroll"
-                    id="btn-enroll"
-                    name="button-enroll"
+                    [ngClass]="{'w-50': isCopying}"
+                    type="button"
+                    title="Copy"
+                    id="btn-copy"
+                    name="button-copy"
                     class="btn btn-info"
-                    [disabled]="isEnrolling"
-                    (click)="submitEnrollData()">
-                  <tm-progress-bar *ngIf="isEnrolling"></tm-progress-bar>
-                  <tm-ajax-loading *ngIf="isEnrolling"></tm-ajax-loading>
+                    [disabled]="isCopying"
+                    (click)="copyStudents()">
+                  <tm-progress-bar *ngIf="isCopying"></tm-progress-bar>
+                  <tm-ajax-loading *ngIf="isCopying"></tm-ajax-loading>
                   Copy students
                 </button>
                 <button

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
@@ -69,8 +69,9 @@
 }
 
 .enroll-button-group {
+  display: flex;
+  justify-content: space-between;
   width: 50%;
-  display: inline-block;
 }
 
 .enroll-button-group * {

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -248,6 +248,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
 
   /**
    * Copies data from existing students HOT to new students HOT
+   * The data is copied only if the existing students tab is expanded
    */
   copyStudents(): void {
     this.isCopying = true;
@@ -255,122 +256,30 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
     this.allStudentChunks = [];
 
     const lastColIndex: number = 4;
+    const existingStudentsHOTInstance: Handsontable =
+        this.hotRegisterer.getInstance(this.existingStudentsHOT);
     const newStudentsHOTInstance: Handsontable =
         this.hotRegisterer.getInstance(this.newStudentsHOT);
+    const existingStudentsData: Handsontable.CellValue[] = existingStudentsHOTInstance.getData();
     const hotInstanceColHeaders: string[] = (newStudentsHOTInstance.getColHeader() as string[]);
 
-    // Reset error highlighting on a new submission
+
+    if (existingStudentsData.length == 0) {
+      this.copyErrorMessage = 'No data to copy from existing students.';
+      this.isCopying = false;
+      return;
+    }
+
+    newStudentsHOTInstance.loadData(existingStudentsData);
+
+    // Reset styles on new students HOT
     this.resetTableStyle(newStudentsHOTInstance, 0,
         newStudentsHOTInstance.getData().length - 1,
         0,
         hotInstanceColHeaders.indexOf(this.colHeaders[lastColIndex]));
 
-    // Remove error highlight on click
-    newStudentsHOTInstance.addHook('afterSelectionEnd', (row: number, column: number,
-                                                          row2: number, column2: number) => {
-      this.resetTableStyle(newStudentsHOTInstance, row, row2, column, column2);
-    });
-
-    // Record the row with its index on the table
-    const studentEnrollRequests: Map<number, StudentEnrollRequest> = new Map();
-
-    // Parse the user input to be requests.
-    // Handsontable contains null value initially,
-    // see https://github.com/handsontable/handsontable/issues/3927
-    newStudentsHOTInstance.getData()
-        .forEach((row: string[], index: number) => {
-          if (!row.every((cell: string) => cell === null || cell === '')) {
-            studentEnrollRequests.set(index, {
-              section: row[hotInstanceColHeaders.indexOf(this.colHeaders[0])] === null
-                  ? '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[0])].trim(),
-              team: row[hotInstanceColHeaders.indexOf(this.colHeaders[1])] === null
-                  ? '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[1])].trim(),
-              name: row[hotInstanceColHeaders.indexOf(this.colHeaders[2])] === null
-                  ? '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[2])].trim(),
-              email: row[hotInstanceColHeaders.indexOf(this.colHeaders[3])] === null
-                  ? '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[3])].trim(),
-              comments: row[hotInstanceColHeaders.indexOf(this.colHeaders[4])] === null
-                  ? '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[4])].trim(),
-            });
-          }
-        });
-
-    if (studentEnrollRequests.size === 0) {
-      this.enrollErrorMessage = 'Empty table';
-      this.isEnrolling = false;
-      return;
-    }
-
-    this.checkCompulsoryFields(studentEnrollRequests);
-    this.checkEmailNotRepeated(studentEnrollRequests);
-    this.checkTeamsValid(studentEnrollRequests);
-
-    if (this.invalidRowsIndex.size > 0) {
-      this.setTableStyleBasedOnFieldChecks(newStudentsHOTInstance, hotInstanceColHeaders);
-      this.isEnrolling = false;
-      return;
-    }
-
-    this.partitionStudentEnrollRequests(Array.from(studentEnrollRequests.values()));
-    const enrolledStudents: Student[] = [];
-
-    // Use concat because we cannot afford to parallelize with forkJoin when there's data dependency
-    const enrollRequests: Observable<EnrollStudents> = concat(
-        ...this.allStudentChunks.map((studentChunk: StudentEnrollRequest[]) => {
-          const request: StudentsEnrollRequest = {
-            studentEnrollRequests: studentChunk,
-          };
-          return this.studentService.enrollStudents(
-              this.courseId, request,
-          );
-        }),
-    );
-
-    this.progressBarService.updateProgress(0);
-    enrollRequests.pipe(finalize(() => {
-      this.isEnrolling = false;
-    })).subscribe({
-      next: (resp: EnrollStudents) => {
-        enrolledStudents.push(...resp.studentsData.students);
-
-        if (resp.unsuccessfulEnrolls != null) {
-          for (const unsuccessfulEnroll of resp.unsuccessfulEnrolls) {
-            this.unsuccessfulEnrolls[unsuccessfulEnroll.studentEmail] = unsuccessfulEnroll.errorMessage;
-
-            for (const index of studentEnrollRequests.keys()) {
-              if (studentEnrollRequests.get(index)?.email === unsuccessfulEnroll.studentEmail) {
-                this.invalidRowsIndex.add(index);
-                break;
-              }
-            }
-          }
-        }
-        const percentage: number = Math.round(100 * enrolledStudents.length / studentEnrollRequests.size);
-        this.progressBarService.updateProgress(percentage);
-      },
-      complete: () => {
-        this.showEnrollResults = true;
-        this.statusMessage.pop(); // removes any existing error status message
-        this.statusMessageService.showSuccessToast('Enrollment successful. Summary given below.');
-        this.prepareEnrollmentResults(enrolledStudents, studentEnrollRequests);
-
-        if (this.invalidRowsIndex.size > 0
-          || this.newStudentRowsIndex.size > 0
-          || this.modifiedStudentRowsIndex.size > 0
-          || this.unchangedStudentRowsIndex.size > 0) {
-          this.setTableStyleBasedOnFieldChecks(newStudentsHOTInstance, hotInstanceColHeaders);
-        }
-      },
-      error: (resp: ErrorMessageOutput) => {
-        if (enrolledStudents.length > 0) {
-          this.showEnrollResults = true;
-          this.prepareEnrollmentResults(enrolledStudents, studentEnrollRequests);
-        }
-
-        // Set error message after populating result panels to avoid it being overridden
-        this.enrollErrorMessage = resp.error.message;
-      },
-    });
+    this.isCopying = false;
+    this.statusMessageService.showSuccessToast('Students copied successfully.');
   }
 
   private prepareEnrollmentResults(enrolledStudents: Student[],

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -262,30 +262,29 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
         this.hotRegisterer.getInstance(this.newStudentsHOT);
     const hotInstanceColHeaders: string[] = (newStudentsHOTInstance.getColHeader() as string[]);
 
-    const copyData = () => {
+    const copyData = (): void => {
       const existingStudentsData: Handsontable.CellValue[] = existingStudentsHOTInstance.getData();
-  
+
       if (existingStudentsData.length === 0) {
         this.copyErrorMessage = 'No data to copy from existing students.';
         this.isCopying = false;
         return;
       }
-  
+
       newStudentsHOTInstance.loadData(existingStudentsData);
-  
+
       this.resetTableStyle(newStudentsHOTInstance, 0,
           newStudentsHOTInstance.getData().length - 1,
           0,
           hotInstanceColHeaders.indexOf(this.colHeaders[lastColIndex]));
-  
+
       this.isCopying = false;
       this.statusMessageService.showSuccessToast('Students copied successfully.');
     };
 
     if (this.isExistingStudentsPanelCollapsed) {
       this.toggleExistingStudentsPanel(copyData);
-    }
-    else {
+    } else {
       copyData();
     }
   }

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -2,11 +2,13 @@
 
 exports[`SessionSubmissionPageComponent should snap when feedback session questions have failed to load 1`] = `
 <tm-session-submission-page
+  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
+  autoSaveDelay={[Function Number]}
   backendUrl={[Function String]}
   commentService={[Function FeedbackResponseCommentService]}
   courseId={[Function String]}
@@ -44,6 +46,7 @@ exports[`SessionSubmissionPageComponent should snap when feedback session questi
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
+  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName=""
@@ -160,11 +163,13 @@ exports[`SessionSubmissionPageComponent should snap when feedback session questi
 
 exports[`SessionSubmissionPageComponent should snap when saving responses 1`] = `
 <tm-session-submission-page
+  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
+  autoSaveDelay={[Function Number]}
   backendUrl={[Function String]}
   commentService={[Function FeedbackResponseCommentService]}
   courseId={[Function String]}
@@ -202,6 +207,7 @@ exports[`SessionSubmissionPageComponent should snap when saving responses 1`] = 
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
+  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName=""
@@ -315,11 +321,13 @@ exports[`SessionSubmissionPageComponent should snap when saving responses 1`] = 
 
 exports[`SessionSubmissionPageComponent should snap with default fields 1`] = `
 <tm-session-submission-page
+  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
+  autoSaveDelay={[Function Number]}
   backendUrl={[Function String]}
   commentService={[Function FeedbackResponseCommentService]}
   courseId={[Function String]}
@@ -357,6 +365,7 @@ exports[`SessionSubmissionPageComponent should snap with default fields 1`] = `
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
+  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName=""
@@ -470,11 +479,13 @@ exports[`SessionSubmissionPageComponent should snap with default fields 1`] = `
 
 exports[`SessionSubmissionPageComponent should snap with feedback session and user details 1`] = `
 <tm-session-submission-page
+  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
+  autoSaveDelay={[Function Number]}
   backendUrl={[Function String]}
   commentService={[Function FeedbackResponseCommentService]}
   courseId={[Function String]}
@@ -512,6 +523,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session and us
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
+  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail={[Function String]}
   personName={[Function String]}
@@ -758,11 +770,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session and us
 
 exports[`SessionSubmissionPageComponent should snap with feedback session question submission forms 1`] = `
 <tm-session-submission-page
+  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
+  autoSaveDelay={[Function Number]}
+  autoSaveTimeout={[Function Number]}
   backendUrl={[Function String]}
   commentService={[Function FeedbackResponseCommentService]}
   courseId={[Function String]}
@@ -800,6 +815,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
+  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName=""
@@ -1290,6 +1306,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                       Submit Response for Question 1
                     </span>
                   </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 1
+                  </button>
                 </div>
               </div>
             </div>
@@ -1546,6 +1570,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     <span>
                       Submit Response for Question 3
                     </span>
+                  </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 3
                   </button>
                 </div>
               </div>
@@ -1980,6 +2012,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                       Submit Response for Question 4
                     </span>
                   </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 4
+                  </button>
                 </div>
               </div>
             </div>
@@ -2194,6 +2234,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     <span>
                       Submit Response for Question 5
                     </span>
+                  </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 5
                   </button>
                 </div>
               </div>
@@ -2423,6 +2471,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     <span>
                       Submit Response for Question 6
                     </span>
+                  </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 6
                   </button>
                 </div>
               </div>
@@ -2883,6 +2939,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                       Submit Response for Question 7
                     </span>
                   </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 7
+                  </button>
                 </div>
               </div>
             </div>
@@ -3227,6 +3291,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                       Submit Response for Question 8
                     </span>
                   </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 8
+                  </button>
                 </div>
               </div>
             </div>
@@ -3509,6 +3581,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                       Submit Response for Question 9
                     </span>
                   </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 9
+                  </button>
                 </div>
               </div>
             </div>
@@ -3741,6 +3821,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                       Submit Response for Question 10
                     </span>
                   </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 10
+                  </button>
                 </div>
               </div>
             </div>
@@ -3770,11 +3858,13 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
 
 exports[`SessionSubmissionPageComponent should snap with feedback session question submission forms when disabled 1`] = `
 <tm-session-submission-page
+  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
+  autoSaveDelay={[Function Number]}
   backendUrl={[Function String]}
   commentService={[Function FeedbackResponseCommentService]}
   courseId={[Function String]}
@@ -3812,6 +3902,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
+  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName=""
@@ -4307,6 +4398,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     <span>
                       Submit Response for Question 1
                     </span>
+                  </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 1
                   </button>
                 </div>
               </div>
@@ -4563,6 +4662,13 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                       Submit Response for Question 3
                     </span>
                   </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 3
+                  </button>
                 </div>
               </div>
             </div>
@@ -5002,6 +5108,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                       Submit Response for Question 4
                     </span>
                   </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 4
+                  </button>
                 </div>
               </div>
             </div>
@@ -5218,6 +5332,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     <span>
                       Submit Response for Question 5
                     </span>
+                  </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 5
                   </button>
                 </div>
               </div>
@@ -5449,6 +5571,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     <span>
                       Submit Response for Question 6
                     </span>
+                  </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 6
                   </button>
                 </div>
               </div>
@@ -5911,6 +6041,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                       Submit Response for Question 7
                     </span>
                   </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 7
+                  </button>
                 </div>
               </div>
             </div>
@@ -6265,6 +6403,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                       Submit Response for Question 8
                     </span>
                   </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 8
+                  </button>
                 </div>
               </div>
             </div>
@@ -6549,6 +6695,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                       Submit Response for Question 9
                     </span>
                   </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 9
+                  </button>
                 </div>
               </div>
             </div>
@@ -6782,6 +6936,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                       Submit Response for Question 10
                     </span>
                   </button>
+                  <button
+                    class="btn btn-warning float-end"
+                    disabled=""
+                    ngbtooltip="Reset your responses for this question to the last submitted state."
+                    type="button"
+                  >
+                    Reset Question 10
+                  </button>
                 </div>
               </div>
             </div>
@@ -6812,11 +6974,13 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
 
 exports[`SessionSubmissionPageComponent should snap with user that is logged in and using session link 1`] = `
 <tm-session-submission-page
+  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
+  autoSaveDelay={[Function Number]}
   backendUrl={[Function String]}
   commentService={[Function FeedbackResponseCommentService]}
   courseId={[Function String]}
@@ -6854,6 +7018,7 @@ exports[`SessionSubmissionPageComponent should snap with user that is logged in 
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
+  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName={[Function String]}
@@ -6968,11 +7133,13 @@ exports[`SessionSubmissionPageComponent should snap with user that is logged in 
 
 exports[`SessionSubmissionPageComponent should snap with user that is not logged in and using session link 1`] = `
 <tm-session-submission-page
+  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
+  autoSaveDelay={[Function Number]}
   backendUrl={[Function String]}
   commentService={[Function FeedbackResponseCommentService]}
   courseId={[Function String]}
@@ -7010,6 +7177,7 @@ exports[`SessionSubmissionPageComponent should snap with user that is not logged
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
+  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName={[Function String]}

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -123,6 +123,8 @@
                                           [(isSubmitAllClicked)]="isSubmitAllClicked"
                                           [currentSelectedSessionView]="currentSelectedSessionView"
                                           [recipientId]="entry.key"
+                                          (resetFeedback)="resetFeedbackResponses([$event], entry.key)"
+                                          (autoSave)="handleAutoSave($event)"
               ></tm-question-submission-form>
             </ng-container>
           </ng-container>
@@ -133,6 +135,9 @@
                 (click)="saveResponsesForSelectedRecipientQuestions(entry.key, questionSubmissionForms)"
                 [disabled]="isSavingResponses || isSubmissionFormsDisabled"><tm-ajax-loading
                   *ngIf="isSavingResponses"></tm-ajax-loading>Submit Responses for {{ getRecipientName(entry.key) }}</button>
+              <button type="button" class="btn btn-warning float-end" ngbTooltip="Reset your responses for this question to the last submitted state."
+                #resetTooltip="ngbTooltip" (click)="resetResponsesForSelectedRecipientQuestions(entry.key, questionSubmissionForms)"
+                [disabled]="!hasResponseChangedForRecipient(entry.key, questionSubmissionForms)" >Reset Responses for {{ getRecipientName(entry.key) }}</button>
             </div>
           </div>
         </div>
@@ -151,6 +156,8 @@
                                       (deleteCommentEvent)="deleteParticipantComment(i, $event)"
                                       [isQuestionCountOne]="isQuestionCountOne"
                                       [(isSubmitAllClicked)]="isSubmitAllClicked"
+                                      (resetFeedback)="resetFeedbackResponses([$event], null)"
+                                      (autoSave)="handleAutoSave($event)"
           ></tm-question-submission-form>
         </ng-container>
       </ng-container>
@@ -166,6 +173,8 @@
                                    [isQuestionCountOne]="isQuestionCountOne"
                                    [(isSubmitAllClicked)]="isSubmitAllClicked"
                                    [currentSelectedSessionView]="currentSelectedSessionView"
+                                   (resetFeedback)="resetFeedbackResponses([$event], null)"
+                                   (autoSave)="handleAutoSave($event)"
       ></tm-question-submission-form>
     </ng-container>
     <div class="row" *ngIf="questionsNeedingSubmission.length === 0">

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1281,4 +1281,38 @@ describe('SessionSubmissionPageComponent', () => {
     expect(commentSpy).toHaveBeenLastCalledWith(expectedId, Intent.STUDENT_SUBMISSION,
         { key: testQueryParams.key, moderatedperson: '' });
   });
+
+  it('should autosave data to localStorage', () => {
+    const questionId = 'feedback-question-id-mcq';
+    const model: QuestionSubmissionFormModel = deepCopy(testMcqQuestionSubmissionForm);
+    model.hasResponseChangedForRecipients = new Map<string, boolean>().set('r1', true);
+    model.isTabExpandedForRecipients = new Map<string, boolean>().set('r1', true);
+    const event = { id: questionId, model };
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+
+    jest.useFakeTimers();
+    component.handleAutoSave(event);
+    jest.advanceTimersByTime(component.autoSaveDelay);
+
+    expect(setItemSpy).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it('should load autosaved data from localStorage', () => {
+    const questionId = 'feedback-question-id-mcq';
+    const savedModel: any = deepCopy(testMcqQuestionSubmissionForm);
+    savedModel.hasResponseChangedForRecipients = Array.from(new Map<string, boolean>().set('r1', true).entries());
+    savedModel.isTabExpandedForRecipients = Array.from(new Map<string, boolean>().set('r1', true).entries());
+
+    const getItemSpy = jest.spyOn(Storage.prototype, 'getItem')
+      .mockReturnValue(JSON.stringify({ [questionId]: savedModel }));
+
+    component.questionSubmissionForms = [deepCopy(testMcqQuestionSubmissionForm)];
+
+    component.loadAutoSavedData(questionId);
+
+    expect(component.questionSubmissionForms[0].hasResponseChangedForRecipients.get('r1')).toBe(true);
+    expect(component.questionSubmissionForms[0].isTabExpandedForRecipients.get('r1')).toBe(true);
+    expect(getItemSpy).toHaveBeenCalledWith('autosave');
+  });
 });


### PR DESCRIPTION
## Motivation and Context

For instructors who want to batch edit many students, they would have to copy and paste the whole sheet from existing students manually. The slightly clunky cell selection in the sheet would make it sometimes hard to select all students, especially if there are many students.
Therefore, I would suggest the addition of a button to auto-import existing students into the new students sheet below. This would be a QOL change and also helps when instructors want to mass-edit students.

## Changes

Frontend:
1. Added a `copy students` button on the enrol page and formatted it.

Backend:
1. Created functionality to copy existing students' spreadsheet into new students' spreadsheet
  * Ran into the issue that Existing students' spreadsheet has to be expanded for logic to work
  * Another issue was the asynchronous nature of fetching data with API calls in `toggleExistingStudentsPanel`
2. Modify `toggleExistingStudentsPanel` to take in an optional callback
  * This ensures that the data is only copied after it has been successfully loaded

## Video Demo

Before: 


https://github.com/user-attachments/assets/a5cbb0d2-bd77-4b21-b254-388f52fad915






After:


https://github.com/user-attachments/assets/e3b2a84c-10e3-4992-94c8-7a99269f92dc


